### PR TITLE
check_plain() is more like escape than strip_tags()

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ I am {{ hamburgers }}
 ## Functions & Filters
 
 ```
-# check_plain 
+# strip_tags
 {{ myarray.acorn|striptags }} 
 ``` 
 


### PR DESCRIPTION
References:

* https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/check_plain/7
* https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Extension/Core.php#L960 (`twig_escape_filter()`)